### PR TITLE
Configure Discord webhook via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Simple HTTP wrapper for Ollama.
 
 The service listens on port `8080` and exposes a single `POST /generate` endpoint.
 
+### Environment
+
+* `DISCORD_WEBHOOK` - Discord webhook URL used for request logging. If unset, webhook notifications are disabled and a warning is printed on startup.
+
 ## Authentication
 
 Valid API keys are stored in `apikeys.json`. Each request must provide an

--- a/server.js
+++ b/server.js
@@ -7,7 +7,10 @@ const app = express();
 app.use(express.json());
 
 const PORT = 8080;
-const DISCORD_WEBHOOK = 'https://discord.com/api/webhooks/1385648877977206931/-u-4rhcjfofA7jslKEAcWTvzwP9abk4TKft-sG3d6sRQXw2fOY2MG-mSa9niInvLeyZ3';
+const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
+if (!DISCORD_WEBHOOK) {
+  console.warn('Warning: DISCORD_WEBHOOK environment variable not set. Webhook notifications will be disabled.');
+}
 
 // Load API keys from apikeys.json
 const API_KEYS = new Set(
@@ -16,6 +19,7 @@ const API_KEYS = new Set(
 
 // Helper to send webhook notifications (fire and forget)
 function sendWebhook(info) {
+  if (!DISCORD_WEBHOOK) return;
   const embed = {
     title: 'LLM Request',
     fields: [


### PR DESCRIPTION
## Summary
- pull Discord webhook URL from `process.env.DISCORD_WEBHOOK`
- warn when the variable isn't set and skip sending webhooks
- document `DISCORD_WEBHOOK` in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68558acd19048329a4febc1eb54b3655