### PR TITLE
Add .env file to repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DISCORD_WEBHOOK=https://discord.com/api/webhooks/1385648877977206931/-u-4rhcjfofA7jslKEAcWTvzwP9abk4TKft-sG3d6sRQXw2fOY2MG-mSa9niInvLeyZ3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-.env

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The service listens on port `8080` and exposes a single `POST /generate` endpoin
 
 ### Environment
 
+This repository includes a `.env` file with a sample Discord webhook for testing.
+The server reads the following variable from the environment:
+
 * `DISCORD_WEBHOOK` - Discord webhook URL used for request logging. If unset, webhook notifications are disabled and a warning is printed on startup.
 
 ## Authentication


### PR DESCRIPTION
## Summary
- add an example `.env` with a Discord webhook
- stop ignoring `.env`
- document the included `.env` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558fa5315083298a992cd636c3f6ab