### PR TITLE
Use config.json for webhook URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Simple HTTP wrapper for Ollama.
 
 The service listens on port `8080` and exposes a single `POST /generate` endpoint.
 
-### Environment
+### Configuration
 
-This repository includes a `.env` file with a sample Discord webhook for testing.
-The server reads the following variable from the environment:
-
-* `DISCORD_WEBHOOK` - Discord webhook URL used for request logging. If unset, webhook notifications are disabled and a warning is printed on startup.
+This repository includes a `config.json` file with a sample Discord webhook for
+testing. The server reads the `DISCORD_WEBHOOK` value from this file. If it is
+missing, webhook notifications are disabled and a warning is printed on
+startup.
 
 ## Authentication
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "DISCORD_WEBHOOK": "https://discord.com/api/webhooks/1385648877977206931/-u-4rhcjfofA7jslKEAcWTvzwP9abk4TKft-sG3d6sRQXw2fOY2MG-mSa9niInvLeyZ3"
+}

--- a/server.js
+++ b/server.js
@@ -7,9 +7,19 @@ const app = express();
 app.use(express.json());
 
 const PORT = 8080;
-const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
+let DISCORD_WEBHOOK = null;
+try {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'config.json'), 'utf-8')
+  );
+  DISCORD_WEBHOOK = config.DISCORD_WEBHOOK;
+} catch (err) {
+  // ignore errors - handled below
+}
 if (!DISCORD_WEBHOOK) {
-  console.warn('Warning: DISCORD_WEBHOOK environment variable not set. Webhook notifications will be disabled.');
+  console.warn(
+    'Warning: DISCORD_WEBHOOK not found in config.json. Webhook notifications will be disabled.'
+  );
 }
 
 // Load API keys from apikeys.json


### PR DESCRIPTION
## Summary
- read DISCORD_WEBHOOK from new `config.json`
- document new configuration in README
- add sample `config.json`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685590b9c95c8329bc8e17f1c7651147