### PR TITLE
Improve error reporting when backend is unreachable

### DIFF
--- a/server.js
+++ b/server.js
@@ -88,8 +88,19 @@ app.post('/generate', async (req, res) => {
     });
   } catch (err) {
     const duration = Date.now() - start;
-    const status = err.response ? err.response.status : 500;
-    const message = err.response?.data?.error || err.message || 'Unknown error';
+    const status = err.response
+      ? err.response.status
+      : err.code === 'ECONNREFUSED'
+      ? 502
+      : 500;
+    let message;
+    if (err.response && err.response.data && err.response.data.error) {
+      message = err.response.data.error;
+    } else if (err.code === 'ECONNREFUSED') {
+      message = 'Upstream service unavailable';
+    } else {
+      message = err.message || 'Unknown error';
+    }
     const evalCount = err.response && err.response.data ? err.response.data.eval_count : undefined;
 
     res.status(status).json({ error: message });


### PR DESCRIPTION
## Summary
- refine `/generate` endpoint error handling
- return a clearer message (`Upstream service unavailable`) if the Ollama backend can't be reached

## Testing
- `npm test`
- `node server.js` & manual curl request (fails due to missing backend)


------
https://chatgpt.com/codex/tasks/task_e_6855937e416c8329b479f9e9fd6f5b7a