### PR TITLE
Return final text as single field

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Simple HTTP wrapper for Ollama.
    ```
 
 The service listens on port `8080` and exposes a single `POST /generate` endpoint.
+This endpoint returns a JSON response with a single `text` field containing the
+final model output. Any `<think>` blocks produced by the model are removed
+before the text is returned.
 
 ### Configuration
 

--- a/__tests__/generate.test.js
+++ b/__tests__/generate.test.js
@@ -40,6 +40,6 @@ describe('POST /generate', () => {
       .post('/generate')
       .send({ prompt: 'hi', api_key: validKey });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ response: 'Hello world' });
+    expect(res.body).toEqual({ text: 'Hello world' });
   });
 });

--- a/server.js
+++ b/server.js
@@ -77,7 +77,7 @@ app.post('/generate', async (req, res) => {
     }
 
     const evalCount = ollamaResp.data.eval_count;
-    res.status(200).json({ response: text });
+    res.status(200).json({ text });
 
     sendWebhook({
       status: 200,


### PR DESCRIPTION
## Summary
- return the combined text using a `text` property
- document response format in README
- update tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559c61f14883298bbaf7d59d87aebd