### PR TITLE
Add API usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ startup.
 Valid API keys are stored in `apikeys.json`. Each request must provide an
 `api_key` in the JSON body (or header). Requests with missing or invalid keys
 will receive **401 Unauthorized**.
+
+## API Usage Example
+
+Once the server is running you can send a request to `/generate` to obtain text from the model:
+
+```bash
+curl -X POST http://localhost:8080/generate \
+     -H "Content-Type: application/json" \
+     -d '{"api_key": "<your-key>", "prompt": "Tell me a joke"}'
+```
+
+Replace `<your-key>` with a value from `apikeys.json`. The response will look like:
+
+```json
+{ "text": "...model output..." }
+```


### PR DESCRIPTION
## Summary
- document how to call the API with curl

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559d622d488329a301bb471fecf8cd