### PR TITLE
Update Ollama host to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Simple HTTP wrapper for Ollama.
 
+This server assumes an Ollama instance is running locally at
+`http://localhost:11434`.
+
 ## Setup
 
 1. Install dependencies:

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ app.post('/generate', async (req, res) => {
 
   const start = Date.now();
   try {
-    const ollamaResp = await axios.post('http://192.168.1.184:11434/api/generate', {
+    const ollamaResp = await axios.post('http://localhost:11434/api/generate', {
       model: 'deepseek-r1:latest',
       prompt,
       stream: false


### PR DESCRIPTION
## Summary
- use `localhost` for the Ollama server in `server.js`
- document the local Ollama requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68576af4e434832996a301d69bdc8d9a