### PR TITLE
Add input/output logging to webhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.10.0",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "form-data": "^4.0.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "type": "commonjs",
   "dependencies": {
     "axios": "^1.10.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- attach `input.json` and `output.json` files to webhook posts
- include prompt and generated text in webhook notification
- add `form-data` dependency for multipart webhook payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577b39bde48329967e3a670cb8b509