### PR TITLE
Add system prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This server assumes an Ollama instance is running locally at
 The service listens on port `8080` and exposes a single `POST /generate` endpoint.
 This endpoint returns a JSON response with a single `text` field containing the
 final model output. Any `<think>` blocks produced by the model are removed
-before the text is returned.
+before the text is returned. The request body must include a `prompt` and may
+optionally include a `system` message which is forwarded to Ollama as the system
+prompt.
 
 ### Configuration
 
@@ -43,7 +45,7 @@ Once the server is running you can send a request to `/generate` to obtain text 
 ```bash
 curl -X POST http://hanging.wang:8080/generate \
      -H "Content-Type: application/json" \
-     -d '{"api_key": "API_KEY", "prompt": "How occurances of the letter \"r\" are there in the word \"strawberry\"?"}'
+     -d '{"api_key": "API_KEY", "prompt": "How occurances of the letter \"r\" are there in the word \"strawberry\"?", "system": "You are a helpful assistant."}'
 ```
 
 Replace `API_KEY` with a value from `apikeys/apikeys.json`. The response will look like:

--- a/__tests__/generate.test.js
+++ b/__tests__/generate.test.js
@@ -42,4 +42,16 @@ describe('POST /generate', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ text: 'Hello world' });
   });
+
+  test('forwards system prompt when provided', async () => {
+    axios.post.mockResolvedValueOnce(mockResponse);
+    axios.post.mockResolvedValue({});
+    const system = 'You are a pirate.';
+    await request(app)
+      .post('/generate')
+      .send({ prompt: 'hi', api_key: validKey, system });
+    const call = axios.post.mock.calls[0];
+    expect(call[0]).toBe('http://localhost:11434/api/generate');
+    expect(call[1]).toEqual(expect.objectContaining({ system }));
+  });
 });

--- a/server.js
+++ b/server.js
@@ -83,6 +83,7 @@ app.post('/generate', async (req, res) => {
   }
 
   const prompt = req.body.prompt;
+  const system = req.body.system;
   if (!prompt) {
     res.status(400).json({ error: 'Missing prompt' });
     sendWebhook({ status: 400, apiKey, ip: req.ip });
@@ -91,11 +92,19 @@ app.post('/generate', async (req, res) => {
 
   const start = Date.now();
   try {
-    const ollamaResp = await axios.post('http://localhost:11434/api/generate', {
+    const payload = {
       model: 'deepseek-r1:latest',
       prompt,
       stream: false
-    }, { headers: { 'Content-Type': 'application/json' } });
+    };
+    if (system) {
+      payload.system = system;
+    }
+    const ollamaResp = await axios.post(
+      'http://localhost:11434/api/generate',
+      payload,
+      { headers: { 'Content-Type': 'application/json' } }
+    );
 
     const duration = Date.now() - start;
     let text = ollamaResp.data.response;


### PR DESCRIPTION
## Summary
- support optional `system` prompt in `/generate`
- document the `system` field in README
- test forwarding of `system` message

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577e6656b88329912848fb1ca0eebe