### PR TITLE
Improve ws API docs and logging

### DIFF
--- a/WS-API/README.md
+++ b/WS-API/README.md
@@ -23,5 +23,11 @@ It exposes `GET /search?q=<query>` which returns JSON:
 { "url": "https://example.com/page", "summary": "first 300 words..." }
 ```
 
+Example request using `curl`:
+
+```bash
+curl "http://localhost:8000/search?q=openai"
+```
+
 The service does not rely on the Google API; it simply fetches Google's search
 results page and follows the first result link.

--- a/WS-API/app.js
+++ b/WS-API/app.js
@@ -81,8 +81,10 @@ const server = http.createServer(async (req, res) => {
     res.end('Missing query');
     return;
   }
+  console.log(`Search request: ${query}`);
 
   const result = await search(query);
+  console.log(`First result for "${query}": ${result.url}`);
   const data = JSON.stringify(result);
   res.writeHead(200, {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- document how to query the WS API using curl
- log queries and returned URLs in the WS API server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685837aa0c3c8329afd3527208332857